### PR TITLE
Don't send multiple requests to vMix at once

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fim-ftc-vmix-switcher",
-    "version": "0.1.0",
+    "version": "0.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "fim-ftc-vmix-switcher",
-            "version": "0.1.0",
+            "version": "0.1.2",
             "license": "MIT",
             "dependencies": {
                 "got": "^11.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fim-ftc-vmix-switcher",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "App to Control vMix Video Output from FTC Scorekeeper's API",
     "main": "dist/index.js",
     "scripts": {


### PR DESCRIPTION
Limits the time between updates to vMix to a minimum of 1500ms. To facilitate this, we batch all incoming events and only process the one with the latest timestamp. Note this does add 50ms of latency to typical event processing going forward.

Fixes #1 